### PR TITLE
Texture improvements

### DIFF
--- a/Texture.py
+++ b/Texture.py
@@ -56,13 +56,16 @@ def decodeTexture(data, size, pitch, swizzled, bits_per_pixel, channel_sizes, ch
       pixels[x, y] = pixel_channels
 
   return img
-      
 
 def dumpTexture(xbox, offset, pitch, fmt_color, width, height):
   img = None
 
   # bits per pixel, channel sizes, channel offsets.
   # Right hand side is always in RGB or RGBA channel order.
+  Y8 = (8, (8, 8, 8), (0, 0, 0))
+  AY8 = (8, (8, 8, 8, 8), (0, 0, 0, 0))
+  A8 = (8, (0, 0, 0, 8), (0, 0, 0, 0))
+  A8Y8 = (16, (8, 8, 8, 8), (0, 0, 0, 8))
   R5G6B5 = (16, (5,6,5), (11, 5, 0))
   A4R4G4B4 = (16, (4,4,4,4), (8, 4, 0, 12))
   A1R5G5B5 = (16, (5,5,5,1), (10, 5, 0, 15))
@@ -70,7 +73,9 @@ def dumpTexture(xbox, offset, pitch, fmt_color, width, height):
   A8R8G8B8 = (32, (8,8,8,8), (16, 8, 0, 24))
   X8R8G8B8 = (32, (8,8,8), (16, 8, 0))
 
-  if fmt_color == 0x2: tex_info = (True, A1R5G5B5)
+  if fmt_color == 0x0: tex_info = (True, Y8)
+  elif fmt_color == 0x1: tex_info = (True, AY8)
+  elif fmt_color == 0x2: tex_info = (True, A1R5G5B5)
   elif fmt_color == 0x3: tex_info = (True, X1R5G5B5)
   elif fmt_color == 0x4: tex_info = (True, A4R4G4B4)
   elif fmt_color == 0x5: tex_info = (True, R5G6B5)
@@ -89,6 +94,8 @@ def dumpTexture(xbox, offset, pitch, fmt_color, width, height):
   elif fmt_color == 0x10: tex_info = (False, A1R5G5B5A5)
   elif fmt_color == 0x11: tex_info = (False, R5G6B5)
   elif fmt_color == 0x12: tex_info = (False, A8R8G8B8)
+  elif fmt_color == 0x19: tex_info = (True, A8)
+  elif fmt_color == 0x1A: tex_info = (True, A8Y8)
   elif fmt_color == 0x1C: tex_info = (False, X1R5G5B5)
   elif fmt_color == 0x1D: tex_info = (False, A4R4G4B4)
   elif fmt_color == 0x1E: tex_info = (False, X8R8G8B8)

--- a/Texture.py
+++ b/Texture.py
@@ -43,7 +43,16 @@ def decodeTexture(data, size, pitch, swizzled, bits_per_pixel, channel_sizes, ch
 
       pixel_channels = ()
       for channel_offset, channel_size in zip(channel_offsets, channel_sizes):
-        pixel_channels += (get_bits(pixel_bits, channel_offset, channel_size),)
+        channel_value = get_bits(pixel_bits, channel_offset, channel_size)
+
+        # Normalize channel
+        if channel_size > 0:
+          channel_value /= (1 << channel_size) - 1
+          channel_value = int(channel_value * 0xFF)
+        else:
+          channel_value = 0x00
+
+        pixel_channels += (channel_value,)
       pixels[x, y] = pixel_channels
 
   return img

--- a/Texture.py
+++ b/Texture.py
@@ -28,10 +28,7 @@ def decodeTexture(data, size, pitch, swizzled, bits_per_pixel, channel_sizes, ch
 
   #FIXME: Unswizzle data on the fly instead
   if swizzled:
-    if width == 640 and height <= 480 and pitch == 2560:
-      data = nv2a.Unswizzle(data, bits_per_pixel, (width, height), pitch)
-    else:
-      data = nv2a._Unswizzle(data, bits_per_pixel, (width, height), pitch)
+    data = nv2a.Unswizzle(data, bits_per_pixel, (width, height), pitch)
 
   pixels = img.load() # create the pixel map
 

--- a/Texture.py
+++ b/Texture.py
@@ -81,7 +81,7 @@ def dumpTexture(xbox, offset, pitch, fmt_color, width, height):
   elif fmt_color == 0x5: tex_info = (True, R5G6B5)
   elif fmt_color == 0x6: tex_info = (True, A8R8G8B8)
   elif fmt_color == 0x7: tex_info = (True, X8R8G8B8)
-  elif fmt_color == 0xB: pass #FIXME! Palette mode!
+  elif fmt_color == 0xB: img = Image.new('RGB', (width, height), (255, 0, 255, 255)) #FIXME! Palette mode!
   elif fmt_color == 0xC: # DXT1
     data = xbox.read(0x80000000 | offset, width * height // 2)
     img = Image.frombytes('RGBA', (width, height), data, 'bcn', 1) # DXT1
@@ -99,9 +99,9 @@ def dumpTexture(xbox, offset, pitch, fmt_color, width, height):
   elif fmt_color == 0x1C: tex_info = (False, X1R5G5B5)
   elif fmt_color == 0x1D: tex_info = (False, A4R4G4B4)
   elif fmt_color == 0x1E: tex_info = (False, X8R8G8B8)
-  elif fmt_color == 0x2E: pass #FIXME! Depth format
-  elif fmt_color == 0x30: pass #FIXME! Depth format
-  elif fmt_color == 0x31: pass #FIXME! Depth format
+  elif fmt_color == 0x2E: img = Image.new('RGB', (width, height), (255, 0, 255, 255)) #FIXME! Depth format
+  elif fmt_color == 0x30: img = Image.new('RGB', (width, height), (255, 0, 255, 255)) #FIXME! Depth format
+  elif fmt_color == 0x31: img = Image.new('RGB', (width, height), (255, 0, 255, 255)) #FIXME! Depth format
   else:
     raise Exception("Unknown texture format: 0x%X" % fmt_color)
 

--- a/Texture.py
+++ b/Texture.py
@@ -79,13 +79,13 @@ def dumpTexture(xbox, offset, pitch, fmt_color, width, height):
   elif fmt_color == 0xB: pass #FIXME! Palette mode!
   elif fmt_color == 0xC: # DXT1
     data = xbox.read(0x80000000 | offset, width * height // 2)
-    img = Image.frombytes('RGB', img.size, data, 'bcn', 1) # DXT1
+    img = Image.frombytes('RGBA', (width, height), data, 'bcn', 1) # DXT1
   elif fmt_color == 0xE: # DXT3
     data = xbox.read(0x80000000 | offset, width * height * 1)
-    img = Image.frombytes('RGBA', img.size, data, 'bcn', 2) # DXT3
+    img = Image.frombytes('RGBA', (width, height), data, 'bcn', 2) # DXT3
   elif fmt_color == 0xF: # DXT5
     data = xbox.read(0x80000000 | offset, width * height * 1)
-    img = Image.frombytes('RGBA', img.size, data, 'bcn', 3) # DXT5
+    img = Image.frombytes('RGBA', (width, height), data, 'bcn', 3) # DXT5
   elif fmt_color == 0x10: tex_info = (False, A1R5G5B5A5)
   elif fmt_color == 0x11: tex_info = (False, R5G6B5)
   elif fmt_color == 0x12: tex_info = (False, A8R8G8B8)

--- a/Trace.py
+++ b/Trace.py
@@ -120,9 +120,7 @@ def recordPGRAPHMethod(xbox, method, data):
           surface_type = xbox.read_u32(0xFD400710)
           swizzle_unk = xbox.read_u32(0xFD400818)
 
-          #FIXME: This does not seem to be a good field for this
-          #FIXME: Patched to give 50% of coolness
-          swizzled = commandCount & 1 #((surface_type & 3) == 1)
+          swizzled = ((surface_type & 3) == 2)
           #FIXME: if surface_type is 0, we probably can't even draw..
 
           color_fmt = (draw_format >> 12) & 0xF


### PR DESCRIPTION
This does a lot of good things for the texture decoder.
See commit titles for more information.

It also removes a hack in the surface decoder (which used a random swizzle-flag), so that the `Unswizzle` function doesn't cause errors.

This code also depends on https://github.com/XboxDev/xboxpy/pull/28.
However, even with these changes, some surfaces and textures will appear broken.
This is related to tiling and will be addressed in a later change (See #10 where this was documented as unknown).