### PR TITLE
Avoid PGRAPH register usage analysis in tracing code

### DIFF
--- a/Trace.py
+++ b/Trace.py
@@ -28,7 +28,7 @@ surface_clip_x = 0
 surface_clip_y = 0
 surface_pitch = 0
 
-pgraph_dump = None
+pgraph_dump = False
 
 def dumpPGRAPH(xbox):
   buffer = bytearray([])
@@ -44,6 +44,10 @@ def dumpPGRAPH(xbox):
   assert(len(buffer) == 0x2000)
   return bytes(buffer)
 
+def output(suffix, contents):
+  global commandCount
+  with open(("out/command%d_" % commandCount)+ suffix, "wb") as f:
+    f.write(contents)
 
 def recordPGRAPHMethod(xbox, method, data):
   global pgraph_dump
@@ -66,27 +70,24 @@ def recordPGRAPHMethod(xbox, method, data):
     print("Zeta clear value!")
 
   if method == 0x1d90:
-    pgraph_dump = dumpPGRAPH(xbox)
+    output("pgraph.bin", dumpPGRAPH(xbox))
+    pgraph_dump = True
     print("Color clear value!")
 
   #FIXME: This shouldn't be necessary, but I can't find this address in PGRAPH
   if method == 0x0200:
-    #pgraph_dump = dumpPGRAPH(xbox)
     print("Changing surface clip x")
     surface_clip_x = data
   if method == 0x0204:
-    #pgraph_dump = dumpPGRAPH(xbox)
     print("Changing surface clip y")
     surface_clip_y = data
   if method == 0x0208:
     print("Changing surface format")
     # Anti-aliasing in 0x00400710
   if method == 0x020c:
-    #pgraph_dump = dumpPGRAPH(xbox)
     print("Changing surface pitch")
     # 0x00400858 and 0x0040085C in pgraph
   if method == 0x0210:
-    #pgraph_dump = dumpPGRAPH(xbox)
     print("Changing color surface address")
     #FIXME: Mabye in PGRAPH: 0x00400828 ? [modified by command]
     color_offset = data
@@ -166,109 +167,10 @@ def recordPushBufferCommand(xbox, v_dma_get_addr):
   global pgraph_dump
 
   # Debug feature to understand PGRAPH
-  if pgraph_dump != None:
-    new_pgraph_dump = dumpPGRAPH(xbox)
-
-    # This blacklist was created from a CLEAR_COLOR, CLEAR
-    blacklist = []
-    blacklist += [0x0040000C] # 0xF3DF0479 → 0xF3DE04F9
-    blacklist += [0x0040002C] # 0xF3DF37FF → 0xF3DE37FF
-    blacklist += [0x0040010C] # 0x03DF0000 → 0x020000F1
-    blacklist += [0x0040012C] # 0x13DF379F → 0x131A37FF
-    blacklist += [0x00400704] # 0x00001D9C → 0x00001D94
-    blacklist += [0x00400708] # 0x01DF0000 → 0x000000F1
-    blacklist += [0x0040070C] # 0x01DF0000 → 0x000000F1
-    blacklist += [0x0040072C] # 0x01DF2700 → 0x000027F1
-    blacklist += [0x00400740] # 0x01DF37DD → 0x01DF37FF
-    blacklist += [0x00400744] # 0x18111D9C → 0x18111D94
-    blacklist += [0x00400748] # 0x01DF0011 → 0x000000F1
-    blacklist += [0x0040074C] # 0x01DF0097 → 0x000000F7
-    blacklist += [0x00400750] # 0x00DF005C → 0x00DF0064
-    blacklist += [0x00400760] # 0x000000CC → 0x000000FF
-    blacklist += [0x00400764] # 0x08001D9C → 0x08001D94
-    blacklist += [0x00400768] # 0x01DF0000 → 0x000000F1
-    blacklist += [0x0040076C] # 0x01DF0000 → 0x000000F1
-    blacklist += [0x00400788] # 0x01DF110A → 0x000011FB
-    blacklist += [0x004007A0] # 0x00200100 → 0x00201D70
-    blacklist += [0x004007A4] # 0x00200100 → 0x00201D70
-    blacklist += [0x004007A8] # 0x00200100 → 0x00201D70
-    blacklist += [0x004007AC] # 0x00200100 → 0x00201D70
-    blacklist += [0x004007B0] # 0x00200100 → 0x00201D70
-    blacklist += [0x004007B4] # 0x00200100 → 0x00201D70
-    blacklist += [0x004007B8] # 0x00200100 → 0x00201D70
-    blacklist += [0x004007BC] # 0x00200100 → 0x00201D70
-    blacklist += [0x004007C0] # 0x00000000 → 0x000006C9
-    blacklist += [0x004007C4] # 0x00000000 → 0x000006C9
-    blacklist += [0x004007C8] # 0x00000000 → 0x000006C9
-    blacklist += [0x004007CC] # 0x00000000 → 0x000006C9
-    blacklist += [0x004007D0] # 0x00000000 → 0x000006C9
-    blacklist += [0x004007D4] # 0x00000000 → 0x000006C9
-    blacklist += [0x004007D8] # 0x00000000 → 0x000006C9
-    blacklist += [0x004007DC] # 0x00000000 → 0x000006C9
-    blacklist += [0x004007E0] # 0x00000000 → 0x000006C9
-    blacklist += [0x004007E4] # 0x00000000 → 0x000006C9
-    blacklist += [0x004007E8] # 0x00000000 → 0x000006C9
-    blacklist += [0x004007EC] # 0x00000000 → 0x000006C9
-    blacklist += [0x004007F0] # 0x00000000 → 0x000006C9
-    blacklist += [0x004007F4] # 0x00000000 → 0x000006C9
-    blacklist += [0x004007F8] # 0x00000000 → 0x000006C9
-    blacklist += [0x004007FC] # 0x00000000 → 0x000006C9
-    blacklist += [0x00400D6C] # 0x00000000 → 0xFF000000
-    blacklist += [0x0040110C] # 0x03DF0000 → 0x020000F1
-    blacklist += [0x0040112C] # 0x13DF379F → 0x131A37FF
-    blacklist += [0x00401704] # 0x00001D9C → 0x00001D94
-    blacklist += [0x00401708] # 0x01DF0000 → 0x000000F1
-    blacklist += [0x0040170C] # 0x01DF0000 → 0x000000F1
-    blacklist += [0x0040172C] # 0x01DF2700 → 0x000027F1
-    blacklist += [0x00401740] # 0x01DF37FD → 0x01DF37FF
-    blacklist += [0x00401744] # 0x18111D9C → 0x18111D94
-    blacklist += [0x00401748] # 0x01DF0011 → 0x000000F1
-    blacklist += [0x0040174C] # 0x01DF0097 → 0x000000F7
-    blacklist += [0x00401750] # 0x00DF0064 → 0x00DF006C
-    blacklist += [0x00401760] # 0x000000CC → 0x000000FF
-    blacklist += [0x00401764] # 0x08001D9C → 0x08001D94
-    blacklist += [0x00401768] # 0x01DF0000 → 0x000000F1
-    blacklist += [0x0040176C] # 0x01DF0000 → 0x000000F1
-    blacklist += [0x00401788] # 0x01DF110A → 0x000011FB
-    blacklist += [0x004017A0] # 0x00200100 → 0x00201D70
-    blacklist += [0x004017A4] # 0x00200100 → 0x00201D70
-    blacklist += [0x004017A8] # 0x00200100 → 0x00201D70
-    blacklist += [0x004017AC] # 0x00200100 → 0x00201D70
-    blacklist += [0x004017B0] # 0x00200100 → 0x00201D70
-    blacklist += [0x004017B4] # 0x00200100 → 0x00201D70
-    blacklist += [0x004017B8] # 0x00200100 → 0x00201D70
-    blacklist += [0x004017BC] # 0x00200100 → 0x00201D70
-    blacklist += [0x004017C0] # 0x00000000 → 0x000006C9
-    blacklist += [0x004017C4] # 0x00000000 → 0x000006C9
-    blacklist += [0x004017C8] # 0x00000000 → 0x000006C9
-    blacklist += [0x004017CC] # 0x00000000 → 0x000006C9
-    blacklist += [0x004017D0] # 0x00000000 → 0x000006C9
-    blacklist += [0x004017D4] # 0x00000000 → 0x000006C9
-    blacklist += [0x004017D8] # 0x00000000 → 0x000006C9
-    blacklist += [0x004017DC] # 0x00000000 → 0x000006C9
-    blacklist += [0x004017E0] # 0x00000000 → 0x000006C9
-    blacklist += [0x004017E4] # 0x00000000 → 0x000006C9
-    blacklist += [0x004017E8] # 0x00000000 → 0x000006C9
-    blacklist += [0x004017EC] # 0x00000000 → 0x000006C9
-    blacklist += [0x004017F0] # 0x00000000 → 0x000006C9
-    blacklist += [0x004017F4] # 0x00000000 → 0x000006C9
-    blacklist += [0x004017F8] # 0x00000000 → 0x000006C9
-    blacklist += [0x004017FC] # 0x00000000 → 0x000006C9
-    #blacklist += [0x0040186C] # 0x00000000 → 0xFF000000 # CLEAR COLOR
-    blacklist += [0x0040196C] # 0x00000000 → 0xFF000000
-    blacklist += [0x00401C6C] # 0x00000000 → 0xFF000000
-    blacklist += [0x00401D6C] # 0x00000000 → 0xFF000000
-
-    for i in range(len(pgraph_dump) // 4):
-      off = 0x00400000 + i * 4
-      if off in blacklist:
-        continue
-      word = struct.unpack_from("<L", pgraph_dump, i * 4)[0]
-      new_word = struct.unpack_from("<L", new_pgraph_dump, i * 4)[0]
-      if new_word != word:
-        addHTML(["", "", "", "", "Modified 0x%08X in PGRAPH: 0x%08X &rarr; 0x%08X" % (off, word, new_word)])
-    pgraph_dump = None
-    addHTML(["", "", "", "", "Finished PGRAPH comparison"])
+  if pgraph_dump:
+    output("pgraph.bin", dumpPGRAPH(xbox))
+    pgraph_dump = False
+    addHTML(["", "", "", "", "Dumped PGRAPH as scheduled"])
 
   # Retrieve command type from Xbox
   word = xbox.read_u32(0x80000000 | v_dma_get_addr)
@@ -295,8 +197,8 @@ def recordPushBufferCommand(xbox, v_dma_get_addr):
       if not method_nonincreasing:
         method += 4
 
-  if pgraph_dump != None:
-    addHTML(["", "", "", "", "Dumped PGRAPH for later"])
+  if pgraph_dump:
+    addHTML(["", "", "", "", "Scheduled PGRAPH dumping"])
 
   commandCount += 1
 


### PR DESCRIPTION
The actual tracing code in nv2a-trace should know as little as possible about the GPU.
All decoding and analysis tools should be separate *or* be integrated from separate code using some interface (like callbacks).

However, the existing code did a diff between PGRAPH register dumps as part of the command processor. This breaks this design goal.

This PR modifies it so the state is only written to disk.

Similar changes are planned for the texture and surface dumping.