### PR TITLE
Add tracer constructor, init html after arg parsing

### DIFF
--- a/Trace.py
+++ b/Trace.py
@@ -31,11 +31,19 @@ def _addHTML(xx):
     f.write("<td>%s</td>" % x)
   f.write("</tr>\n")
   f.close()
-f = open(debugLog,"w")
-f.write("<html><head><style>body { font-family: sans-serif; background:#333; color: #ccc } img { border: 1px solid #FFF; } td, tr, table { background: #444; padding: 10px; border:1px solid #888; border-collapse: collapse; }</style></head><body><table>\n")
-#FIXME: atexit close tags.. but yolo!
-f.close()
-_addHTML(["<b>#</b>", "<b>Opcode / Method</b>", "..."])
+
+def setupOutput(outputDir):
+  global OutputDir
+  global debugLog
+
+  OutputDir = outputDir
+  debugLog = os.path.join(OutputDir, "debug.html")
+
+  with open(debugLog,"w") as f:
+    f.write("<html><head><style>body { font-family: sans-serif; background:#333; color: #ccc } img { border: 1px solid #FFF; } td, tr, table { background: #444; padding: 10px; border:1px solid #888; border-collapse: collapse; }</style></head><body><table>\n")
+    #FIXME: atexit close tags.. but yolo!
+
+  _addHTML(["<b>#</b>", "<b>Opcode / Method</b>", "..."])
 
 
 def _htmlPrint(s):
@@ -127,10 +135,9 @@ def _kickFifo(xbox, expected_put):
 
 class Tracer():
 
-  def out(self, suffix, contents):
-    out_path = os.path.join(OutputDir, "command%d_" % self.commandCount) + suffix
-    with open(out_path, "wb") as f:
-      f.write(contents)
+  def __init__(self, dma_get_adrdr, dma_put_addr):
+    self.flipStallCount = 0
+    self.commandCount = 0
 
     self.real_dma_get_addr = dma_get_addr
     self.real_dma_put_addr = dma_put_addr
@@ -580,7 +587,7 @@ class Tracer():
       # Download this command from Xbox
       if (method_count == 0):
         # Halo: CE has cases where method_count is 0?!
-        html_print("Warning: Command 0x%X with method_count == 0\n" % method)
+        _htmlPrint("Warning: Command 0x%X with method_count == 0\n" % method)
         data = []
       else:
         command = xbox.read(0x80000000 | (get_addr + 4), method_count * 4)

--- a/nv2a-trace.py
+++ b/nv2a-trace.py
@@ -48,9 +48,10 @@ def main(args):
   # Create output folder
   try:
     os.mkdir(args.out)
-    Trace.OutputDir = args.out
   except FileExistsError:
     pass
+
+  Trace.setupOutput(args.out)
   
   if args.no_surface:
     Trace.SurfaceDumping = False


### PR DESCRIPTION
Three minor fixes:

- Adds a constructor to the Tracer class, which seems to have been replaced with a duplicate `out` definition. 
- Rework the `debug.html` setup to occur after the args have been parsed. This fixes the file not found error and allows for the html file to be created in the user specified output folder instead of the hard-coded default.
- `htmlPrint` is now called with a consistent function name